### PR TITLE
SITEINFOの不正な正規表現のurlを無視する

### DIFF
--- a/src.safariextension/global.js
+++ b/src.safariextension/global.js
@@ -20,7 +20,12 @@ function init() {
             var res = SITEINFO_IMPORT_URLS.reduce(function(r, url) {
                 return siteinfo[url] ? r.concat(siteinfo[url].info) : r
             }, []).filter(function(s) {
-                return event.message.url.match(s.url)
+                try {
+                    return event.message.url.match(s.url)
+                }
+                catch(e) {
+                    return false
+                }
             })
             event.target.page.dispatchMessage(event.name, res)
         }


### PR DESCRIPTION
safari版では、あるSITEINFOに不正な正規表現のurlが含まれると、他のサイトでもAutoPagerizeが動かなくなるようです。
他ではtry/catchしているのですが、safari版では一箇所抜けているように思います。
